### PR TITLE
B2C-1887 - Ajustando CSS para exibir botão do whatsapp à esquerda e do zendesk à direita, no mobile, ambiente de teste

### DIFF
--- a/src/css/whatsapp-icon.css
+++ b/src/css/whatsapp-icon.css
@@ -1,9 +1,9 @@
 #whatsapp-icon-link {
   bottom: 0px;
   display: none;
-  margin: 20px 15px;
+  margin: 10px 15px;
   position: fixed;
-  right: 0px;
+  left: 0px;
   z-index: 8000;
 }
 
@@ -14,10 +14,19 @@
 
 @media only screen and (max-width: 992px) {
   #launcher {
-    top: -10000px;
+    /* top: -10000px; */
   }
 
   #whatsapp-icon-link {
     display: inherit;
   }
+
+  .search-qd-v1-navigator-trigger {
+    bottom: 80px !important;
+  }
+}
+
+/* apenas para teste no ambiente de dev */
+.fixed-buttons-qd-v1 {
+  display: none;
 }


### PR DESCRIPTION
Ajustando CSS para exibir botão do whatsapp à esquerda e do zendesk à direita, no mobile, ambiente de teste