### PR TITLE
B2C-1885_v2 - Desabilitando temporariamente faixas de CEP para pols. MG40-PE e MG49-PR

### DIFF
--- a/src/js/policies/checkout.js
+++ b/src/js/policies/checkout.js
@@ -33,7 +33,11 @@ const specialCasePolicies = [
     
     { nome: 'PE', Unidade: 'RC01', cMin: 50000000, cMax: 53689999, Uf: 'Pernambuco', salesChannel: 15 },
     { nome: 'PE', Unidade: 'RC01', cMin: 54000000, cMax: 54599999, Uf: 'Pernambuco', salesChannel: 15 },
-    { nome: 'PE', Unidade: 'MG40', cMin: 56300000, cMax: 56354999, Uf: 'Pernambuco', salesChannel: 17 },
+
+    //Políticas desabilitadas devido ao problema de habilitar todas as políticas no site
+    //Quando a VTEX  resolver o chamado, habilitar novamente
+
+    //{ nome: 'PE', Unidade: 'MG40', cMin: 56300000, cMax: 56354999, Uf: 'Pernambuco', salesChannel: 17 },
 
     { nome: 'PR', Unidade: 'MG13', cMin: 80000000, cMax: 83189999, Uf: 'Paraná', salesChannel: 19 },
     { nome: 'PR', Unidade: 'MG13', cMin: 83300000, cMax: 83349999, Uf: 'Paraná', salesChannel: 19 },
@@ -43,13 +47,17 @@ const specialCasePolicies = [
     { nome: 'PR', Unidade: 'MG13', cMin: 83700000, cMax: 83729999, Uf: 'Paraná', salesChannel: 19 },
     { nome: 'PR', Unidade: 'MG13', cMin: 83820000, cMax: 83839999, Uf: 'Paraná', salesChannel: 19 },
 
-    { nome: 'PR', Unidade: 'MG49', cMin: 86730000, cMax: 86754999, Uf: 'Paraná', salesChannel: 20 },
-    { nome: 'PR', Unidade: 'MG49', cMin: 86770000, cMax: 86779999, Uf: 'Paraná', salesChannel: 20 },
-    { nome: 'PR', Unidade: 'MG49', cMin: 86900000, cMax: 86909999, Uf: 'Paraná', salesChannel: 20 },
-    { nome: 'PR', Unidade: 'MG49', cMin: 86975000, cMax: 87119999, Uf: 'Paraná', salesChannel: 20 },
-    { nome: 'PR', Unidade: 'MG49', cMin: 87140000, cMax: 87154999, Uf: 'Paraná', salesChannel: 20 },
-    { nome: 'PR', Unidade: 'MG49', cMin: 87160000, cMax: 87169999, Uf: 'Paraná', salesChannel: 20 },
-    { nome: 'PR', Unidade: 'MG49', cMin: 87780000, cMax: 87789999, Uf: 'Paraná', salesChannel: 20 },
+
+    //Políticas desabilitadas devido ao problema de habilitar todas as políticas no site
+    //Quando a VTEX  resolver o chamado, habilitar novamente
+
+    // { nome: 'PR', Unidade: 'MG49', cMin: 86730000, cMax: 86754999, Uf: 'Paraná', salesChannel: 20 },
+    // { nome: 'PR', Unidade: 'MG49', cMin: 86770000, cMax: 86779999, Uf: 'Paraná', salesChannel: 20 },
+    // { nome: 'PR', Unidade: 'MG49', cMin: 86900000, cMax: 86909999, Uf: 'Paraná', salesChannel: 20 },
+    // { nome: 'PR', Unidade: 'MG49', cMin: 86975000, cMax: 87119999, Uf: 'Paraná', salesChannel: 20 },
+    // { nome: 'PR', Unidade: 'MG49', cMin: 87140000, cMax: 87154999, Uf: 'Paraná', salesChannel: 20 },
+    // { nome: 'PR', Unidade: 'MG49', cMin: 87160000, cMax: 87169999, Uf: 'Paraná', salesChannel: 20 },
+    // { nome: 'PR', Unidade: 'MG49', cMin: 87780000, cMax: 87789999, Uf: 'Paraná', salesChannel: 20 },
  
     { nome: 'SP', Unidade: 'NW01', cMin: 4000000, cMax: 4999999, Uf: 'São Paulo', salesChannel: 27},
     { nome: 'SP', Unidade: 'NW01', cMin: 5600000, cMax: 5899999, Uf: 'São Paulo', salesChannel: 27},


### PR DESCRIPTION
Desabilitando temporariamente faixas de CEP para pols. MG40-PE e MG49-PR, enquanto VTEX não resolve o chamado do problema de selecionar todas as políticas no site